### PR TITLE
fixed bug in name reference

### DIFF
--- a/subscribe-berkeley-groups.php
+++ b/subscribe-berkeley-groups.php
@@ -62,7 +62,7 @@ class Plugin {
   //const SUBSCRIPTION_URL = 'https://groups.google.com/forum/#!forum/%s/join';
 
   // Object reference for JavaScript
-  const PLUGIN_OBJ = 'Subscribe_Google_Groups_AJAX';
+  const PLUGIN_OBJ = 'Google_Groups_Subscribe_AJAX';
 
   // i18n language domain
   const DOMAIN = 'subscribe-berkeley-groups';


### PR DESCRIPTION
Looks like the `PLUGIN_OBJ` was named differently than when it was referenced later. Fixed that, and updated the copyright to be recent as of 2019.